### PR TITLE
Fix load and forecast initialization

### DIFF
--- a/custom_components/solem_bluetooth_watering_controller/api.py
+++ b/custom_components/solem_bluetooth_watering_controller/api.py
@@ -304,7 +304,9 @@ class OpenWeatherMapAPI:
         self.latitude = latitude
         self.longitude = longitude
         self.timeout = timeout
-        self._cache_forecast = None
+        # Initialise the forecast cache as an empty list to avoid iteration
+        # errors before any data is fetched from the API.
+        self._cache_forecast = []
         self._cache_current = None
         self._last_forecast_fetch_time = None
         self.last_forecast_date = datetime.now().date()

--- a/custom_components/solem_bluetooth_watering_controller/coordinator.py
+++ b/custom_components/solem_bluetooth_watering_controller/coordinator.py
@@ -255,7 +255,6 @@ class SolemCoordinator(DataUpdateCoordinator):
                 self.last_sprinkle = last_sprinkle or dt_util.now()
 
             # Normalize all datetimes to be aware
-            from homeassistant.util import dt as dt_util
             from .util import ensure_aware
             self.last_reset = ensure_aware(self.last_reset)
             self.last_rain = ensure_aware(self.last_rain)


### PR DESCRIPTION
## Summary
- fix repeated dt_util import causing UnboundLocalError
- initialize `_cache_forecast` to an empty list so first forecast fetch works

## Testing
- `python -m py_compile custom_components/solem_bluetooth_watering_controller/*.py` *(fails: SyntaxError)*
- `pip install pytest` *(fails: Could not find a version)*