### PR TITLE
Make OpenWeather optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ For each controller that you want to use, you should add a config entry. You wil
 * which is the bluetooth device
 * the number of stations your controller have
 * the controller location (it loads the zones you have in HA)
-* the OpenWeatherMap API key (you will need to create an API key. first you need to create an [account](https://home.openweathermap.org/users/sign_up))
+* the OpenWeatherMap API key (optional, create one by [signing up](https://home.openweathermap.org/users/sign_up) if you want weather based features)
 * sprinkle even when raining (a true/false dropdown - true if you still want to sprinke even if it's raining, false otherwise)
 
 Afterwards an empty irrigation schedule is created. If you want to control it you will need the [Solem Schedule Card](https://github.com/hcraveiro/solem-schedule-card) installed. Previously I had it on the config flow but it is so not user friendly that I decided that a card would be better.

--- a/custom_components/solem_bluetooth_watering_controller/config_flow.py
+++ b/custom_components/solem_bluetooth_watering_controller/config_flow.py
@@ -177,7 +177,7 @@ class SolemConfigFlow(ConfigFlow, domain=DOMAIN):
                 vol.Required(CONF_SENSORS): selector(
                     {"entity": {"domain": "zone"}}
                 ),
-                vol.Required(OPEN_WEATHER_MAP_API_KEY): str,
+                vol.Optional(OPEN_WEATHER_MAP_API_KEY, default=""): str,
                 vol.Required(SPRINKLE_WITH_RAIN): selector(
                     {
                         "select": {
@@ -310,7 +310,7 @@ class SolemConfigFlow(ConfigFlow, domain=DOMAIN):
                     vol.Required(CONF_SENSORS, default=config_entry.data[CONF_SENSORS]): selector(
                         {"entity": {"domain": "zone"}}
                     ),
-                    vol.Required(OPEN_WEATHER_MAP_API_KEY, default=config_entry.data[OPEN_WEATHER_MAP_API_KEY]): str,
+                    vol.Optional(OPEN_WEATHER_MAP_API_KEY, default=config_entry.data.get(OPEN_WEATHER_MAP_API_KEY, "")): str,
                     vol.Required(SPRINKLE_WITH_RAIN, default=config_entry.data[SPRINKLE_WITH_RAIN]): selector(
                         {
                             "select": {

--- a/custom_components/solem_bluetooth_watering_controller/manifest.json
+++ b/custom_components/solem_bluetooth_watering_controller/manifest.json
@@ -12,6 +12,6 @@
   "requirements": ["tenacity"],
   "single_config_entry": false,
   "ssdp": [],
-  "version": "1.0.3",
+  "version": "1.0.4",
   "zeroconf": []
 }

--- a/custom_components/solem_bluetooth_watering_controller/strings.json
+++ b/custom_components/solem_bluetooth_watering_controller/strings.json
@@ -17,7 +17,7 @@
         "title": "Basic data",
         "data": {
           "controller_mac_address": "Controller MAC Address",
-          "open_weather_map_api_key": "OpenWeatherMap API Key",
+          "open_weather_map_api_key": "OpenWeatherMap API Key (optional)",
           "num_stations": "Number of stations",
           "sensors": "Controller location",
           "sprinkle_with_rain": "Sprinkle even when raining"
@@ -26,7 +26,7 @@
       "reconfigure": {
         "data": {
           "controller_mac_address": "Controller MAC Address",
-          "open_weather_map_api_key": "OpenWeatherMap API Key",
+          "open_weather_map_api_key": "OpenWeatherMap API Key (optional)",
           "num_stations": "Number of stations",
           "sensors": "Controller location",
           "sprinkle_with_rain": "Sprinkle even when raining"

--- a/custom_components/solem_bluetooth_watering_controller/translations/en.json
+++ b/custom_components/solem_bluetooth_watering_controller/translations/en.json
@@ -17,7 +17,7 @@
         "title": "Basic data",
         "data": {
           "controller_mac_address": "Controller MAC Address",
-          "open_weather_map_api_key": "OpenWeatherMap API Key",
+          "open_weather_map_api_key": "OpenWeatherMap API Key (optional)",
           "num_stations": "Number of stations",
           "sensors": "Controller location",
           "sprinkle_with_rain": "Sprinkle even when raining"
@@ -26,7 +26,7 @@
       "reconfigure": {
         "data": {
           "controller_mac_address": "Controller MAC Address",
-          "open_weather_map_api_key": "OpenWeatherMap API Key",
+          "open_weather_map_api_key": "OpenWeatherMap API Key (optional)",
           "num_stations": "Number of stations",
           "sensors": "Controller location",
           "sprinkle_with_rain": "Sprinkle even when raining"


### PR DESCRIPTION
## Summary
- make OpenWeatherMap API key optional
- handle missing weather API key in the coordinator
- mark key optional in UI strings and README
- prevent crashes when schedule not initialized
- bump version to 1.0.4

## Testing
- `flake8 || true`
